### PR TITLE
Stopped stripping TL high bits, and print SMPS2ASM version number

### DIFF
--- a/src/tools/fmvoice.cc
+++ b/src/tools/fmvoice.cc
@@ -220,10 +220,8 @@ void fm_voice::print(ostream &out, int sonicver, int id) const {
 	out << endl;
 
 	PrintMacro(out, "smpsVcTotalLevel");
-	static int tlmasks[8] = {0x1, 0x1, 0x1, 0x1, 0x5, 0x7, 0x7, 0xf};
-	int mask = tlmasks[vcAlgorithm];
 	for (int i = 0; i < 4; i++) {
-		PrintHex2(out, (mask & (1 << i)) != 0 ? vcTL[i] & 0x7f : vcTL[i], i == 3);
+		PrintHex2(out, vcTL[i], i == 3);
 	}
 	out << endl << endl;
 }

--- a/src/tools/smps2asm.cc
+++ b/src/tools/smps2asm.cc
@@ -40,6 +40,8 @@
 #include "ignore_unused_variable_warning.h"
 #include "songtrack.h"
 
+#define SMPS2ASM_VERSION 1
+
 using namespace std;
 
 struct S1IO {
@@ -418,7 +420,7 @@ public:
 		// Start with music conversion header.
 		out << projname << "_Header:" << endl;
 		PrintMacro(out, "smpsHeaderStartSong");
-		out << (sonicver > 3 ? 3 : sonicver) << endl;
+		out << (sonicver > 3 ? 3 : sonicver) << ", " << SMPS2ASM_VERSION << endl;
 
 		// Now for voice pointer; this is the first piece of data in both
 		// songs and SFX.


### PR DESCRIPTION
This fixes #1.

See Clownacy/flamedriver@12af013b4ddbd15fa5b180576cff8e329d279ac7 for more